### PR TITLE
Install label studio ml backend from git

### DIFF
--- a/label_studio_ml/default_configs/Dockerfile
+++ b/label_studio_ml/default_configs/Dockerfile
@@ -11,7 +11,7 @@ COPY supervisord.conf /etc/supervisor/conf.d/
 WORKDIR ${HOME}
 
 # RUN pip install git+https://github.com/heartexlabs/label-studio.git@master
-RUN pip install label-studio
+RUN pip install label-studio git+https://github.com/heartexlabs/label-studio-ml-backend
 
 COPY . ${HOME}/
 


### PR DESCRIPTION
Closes #9

Adds `label-studio-ml-backend` as dependency to be installed by `pip` within the Docker image.