### PR TITLE
Update mmdetection.py

### DIFF
--- a/label_studio_ml/examples/mmdetection/mmdetection.py
+++ b/label_studio_ml/examples/mmdetection/mmdetection.py
@@ -85,10 +85,10 @@ class MMDetection(LabelStudioMLBase):
                     'type': 'rectanglelabels',
                     'value': {
                         'rectanglelabels': [output_label],
-                        'x': int(x / img_width * 100),
-                        'y': int(y / img_height * 100),
-                        'width': int((xmax - x) / img_width * 100),
-                        'height': int((ymax - y) / img_height * 100)
+                        'x': x / img_width * 100,
+                        'y': y / img_height * 100,
+                        'width': (xmax - x) / img_width * 100,
+                        'height': (ymax - y) / img_height * 100
                     },
                     'score': score
                 })


### PR DESCRIPTION
Noticed that label-studio shows predicted bounding boxes shifted from the original predictions.

I don't know the reasons behind doing `int()`, but it definitely gives better results without them.