### PR TITLE
Docker set up to support reading checkpoint_file from config.json and documentation

### DIFF
--- a/label_studio_ml/default_configs/Dockerfile
+++ b/label_studio_ml/default_configs/Dockerfile
@@ -15,7 +15,9 @@ COPY supervisord.conf /etc/supervisor/conf.d/
 
 WORKDIR /app
 
+COPY /models/*.pt /app/data/models/
 COPY *.py /app/
+COPY *.json /app/
 
 EXPOSE 9090
 

--- a/label_studio_ml/default_configs/README.md
+++ b/label_studio_ml/default_configs/README.md
@@ -43,7 +43,6 @@ label-studio start --init new_project --ml-backends http://localhost:9090 --temp
    
 ## API guidelines
 
-
 #### Inference module
 In order to create module for inference, you have to declare the following class:
 
@@ -72,6 +71,24 @@ class MyModel(BaseModel):
             predictions.append(task_prediction)
         return predictions
 ```
+
+#### Docker backend
+
+To run the backend via docker:
+
+```bash
+cd new_project
+docker-compose build
+docker-compose up
+```
+
+##### Model `checkpoint_file`
+
+When deploying the backend through docker, you can pass the path to the model's `checkpoint_file` (if required as class argument in your inference model, [see OpenMMLab example](https://labelstud.io/tutorials/object-detector.html)) in the `config.json`. Additionally, make sure to make the model's checkpoint file available inside the docker container, either by copying the file to `/app/data/models` or by creating a volume of the model's directory.   
+
+##### Cloud storage credentials
+
+If label studio is set up to read images from a cloud storage, please make sure to grant docker access to your storage credentials as `environment` parameters in `docker-compose.yml`.
 
 #### Training module
 Training could be made in a separate environment. The only one convention is that data iterator and working directory are specified as input arguments for training function which outputs JSON-serializable resources consumed later by `load()` function in inference module.

--- a/label_studio_ml/default_configs/_wsgi.py.tmpl
+++ b/label_studio_ml/default_configs/_wsgi.py.tmpl
@@ -1,4 +1,5 @@
 import os
+import json
 import argparse
 import logging
 import logging.config
@@ -116,11 +117,14 @@ if __name__ == "__main__":
     app.run(host=args.host, port=args.port, debug=args.debug)
 
 else:
+    kwargs = get_kwargs_from_config()
+
     # for uWSGI use
     app = init_app(
         model_class={model_class},
         model_dir=os.environ.get('MODEL_DIR', os.path.dirname(__file__)),
         redis_queue=os.environ.get('RQ_QUEUE_NAME', 'default'),
         redis_host=os.environ.get('REDIS_HOST', 'localhost'),
-        redis_port=os.environ.get('REDIS_PORT', 6379)
+        redis_port=os.environ.get('REDIS_PORT', 6379),
+        **kwargs
     )

--- a/label_studio_ml/default_configs/config.json
+++ b/label_studio_ml/default_configs/config.json
@@ -1,0 +1,3 @@
+{
+  "checkpoint_file": "./models/checkpoint_file_name"
+}


### PR DESCRIPTION
Hi, 

Created a PR to support passing the model's checkpoint_files in a docker container set up. Here's a sort description of the changes:

1. Even though in `label_studio_ml/default_configs/_wsgi.py.tmpl` there is support for reading the `checkpoint_file` through `config.json` (see method `get_kwargs_from_config()`) the `json` import is missing as well as making the kwargs available to the `uWSGI` app. 
2. Added `config.json` in the `default_configs`
3. Updated `Dockerfile` to copy the `config.json` as well as the `checkpoint_file` that should be placed in `./models/`
4. Updated `README.md` with the instructions on using the backend with docker, including considering the cloud storage credentials and checkpoint file exposure 