### PR TITLE
LABEL_STUDIO_USE_REDIS set to true

### DIFF
--- a/label_studio_ml/default_configs/docker-compose.yml
+++ b/label_studio_ml/default_configs/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - RQ_QUEUE_NAME=default
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - LABEL_STUDIO_USE_REDIS=true
     ports:
       - 9090:9090
     depends_on:


### PR DESCRIPTION
Since the docker-compose.yml includes a redis instance, let's use activate it using the environment variable. otherwise it's deactivated