### PR TITLE
Added missing redis and rq pip dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ label-studio-tools>=0.0.0.dev11
 Jinja2==3.0.3
 itsdangerous==2.0.1
 werkzeug==2.0.2
+redis==4.4.2
+rq==1.12.0


### PR DESCRIPTION
rq and redis, both are imported in _label_studio_ml/model.py_ and other files as well:
`from redis import Redis`
`from rq.job import Job`

but, because _requirements.txt_ does not mention both of these packages, devs have to install these packages when `label-studio-ml init` command fails and requests to install the above packages.