### PR TITLE
fix: Requirements for "label-studio-ml init my_backend" command

### DIFF
--- a/label_studio_ml/model.py
+++ b/label_studio_ml/model.py
@@ -6,6 +6,7 @@ import json
 import redis
 import attr
 import io
+import rq
 try:
     import torch.multiprocessing as mp
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ label-studio-tools>=0.0.0.dev11
 Jinja2==3.0.3
 itsdangerous==2.0.1
 werkzeug==2.0.2
+redis
+rq

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ label-studio-tools>=0.0.0.dev11
 Jinja2==3.0.3
 itsdangerous==2.0.1
 werkzeug==2.0.2
-redis
-rq
+redis<4.6.0
+rq<1.14


### PR DESCRIPTION
I was following two tutorials and had to add redis and rq to the requirements script plus import rq in model.py

The tutorials I was following if you think maybe a step is missing there and the changes didn't need to be made to the repo
https://labelstud.io/guide/ml.html#Quickstart-with-an-example-ML-backend
https://labelstud.io/tutorials/dummy_model.html