### PR TITLE
Updated requirements.txt - label-studio-sdk

### DIFF
--- a/label_studio_ml/examples/the_simplest_backend/requirements.txt
+++ b/label_studio_ml/examples/the_simplest_backend/requirements.txt
@@ -1,6 +1,6 @@
 click==7.1.2
 label-studio-ml==1.0.8
-label-studio-sdk==0.0.21
+label-studio-sdk>=0.0.6
 rq==1.10.0
 supervisor==4.2.2
 uwsgi==2.0.19.1

--- a/label_studio_ml/examples/the_simplest_backend/requirements.txt
+++ b/label_studio_ml/examples/the_simplest_backend/requirements.txt
@@ -1,6 +1,6 @@
 click==7.1.2
 label-studio-ml==1.0.8
-label-studio-sdk>=0.0.6
+label-studio-sdk>=0.0.21
 rq==1.10.0
 supervisor==4.2.2
 uwsgi==2.0.19.1

--- a/label_studio_ml/examples/the_simplest_backend/requirements.txt
+++ b/label_studio_ml/examples/the_simplest_backend/requirements.txt
@@ -1,6 +1,6 @@
 click==7.1.2
 label-studio-ml==1.0.8
-label-studio-sdk==0.0.6
+label-studio-sdk==0.0.21
 rq==1.10.0
 supervisor==4.2.2
 uwsgi==2.0.19.1


### PR DESCRIPTION
Updated label-studio-sdk to 0.0.21 as older versions of the SDK aren't compatible with latest version of Label Studio's API.