### PR TITLE
Fix problem where `python` may not be available as python3 default app

### DIFF
--- a/label_studio_ml/server.py
+++ b/label_studio_ml/server.py
@@ -140,7 +140,7 @@ def create_dir(args):
 def start_server(args, subprocess_params):
     project_dir = os.path.join(args.root_dir, args.project_name)
     wsgi = os.path.join(project_dir, '_wsgi.py')
-    os.system('python ' + wsgi + ' ' + ' '.join(subprocess_params))
+    os.system('python3 ' + wsgi + ' ' + ' '.join(subprocess_params))
 
 
 def deploy_to_gcp(args):


### PR DESCRIPTION
python3 isn't always available as python. Chainging system call to `python3` to be more portable.